### PR TITLE
Inherit 'typing-game-mode' from 'special-mode'

### DIFF
--- a/typing-game.el
+++ b/typing-game.el
@@ -128,7 +128,7 @@
   :group 'typing-game)
 
 
-(define-derived-mode typing-game-mode text-mode "typing-game"
+(define-derived-mode typing-game-mode special-mode "typing-game"
   "Major mode for running typing-game"
   (local-set-key  [remap self-insert-command] 'typing-game-erase)
   (setq show-trailing-whitespace nil)


### PR DESCRIPTION
Hello, is there a reason to use `text-mode`?  If I understand
correctly, it should be used only for buffers with editable text,
and I think it is better to inherit `typing-game` from
`special-mode`: for example, `snake-mode` (M-x snake) or
`life-mode` (M-x life) are inherited from it.
