### PR TITLE
Silence compiler

### DIFF
--- a/typing-game.el
+++ b/typing-game.el
@@ -140,6 +140,8 @@
 (defvar typing-game-start-time (float-time)
   "when this game started")
 
+(defvar typing-game-timer nil)
+
 (defun typing-game-running-p ()
   (timerp typing-game-timer))
 
@@ -153,8 +155,6 @@
   (setq typing-game-total-scores 0)
   (setq typing-game-escaped-characters "")
   (setq typing-game-start-time (float-time)))
-
-(defvar typing-game-timer nil)
 
 ;;;###autoload
 (defun typing-game (speed)


### PR DESCRIPTION
Hello, currently if you compile "typing-game.el" with `emacs -Q`,
you'll get a warning:

```
typing-game.el:145:11:Warning: reference to free variable `typing-game-timer`
```

So what about moving `typing-game-timer` variable before
`typing-game-running-p`?
